### PR TITLE
Change type references to include the 'Fbx' prefix.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -188,3 +188,4 @@ FakesAssemblies/
 # Auto-generated files
 AssemblyInfo.Git.cs
 
+.vs

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ addons:
 script:
   - nuget restore ChamberLib.FbxSharp.sln
   - xbuild /p:Configuration=Debug ChamberLib.FbxSharp.sln
-  - nunit-console ./ChamberLib.FbxSharp.Tests/bin/Debug/ChamberLib.FbxSharp.Tests.dll
+  - mono ./packages/NUnit.ConsoleRunner.3.10.0/tools/nunit3-console.exe ./ChamberLib.FbxSharp.Tests/bin/Debug/ChamberLib.FbxSharp.Tests.dll
 
 branches:
   only:

--- a/ChamberLib.FbxSharp.Tests/ChamberLib.FbxSharp.Tests.csproj
+++ b/ChamberLib.FbxSharp.Tests/ChamberLib.FbxSharp.Tests.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\NUnit.3.12.0\build\NUnit.props" Condition="Exists('..\packages\NUnit.3.12.0\build\NUnit.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -39,7 +40,7 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="nunit.framework">
-      <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
+      <HintPath>..\packages\NUnit.3.12.0\lib\net40\nunit.framework.dll</HintPath>
     </Reference>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />

--- a/ChamberLib.FbxSharp.Tests/packages.config
+++ b/ChamberLib.FbxSharp.Tests/packages.config
@@ -2,5 +2,6 @@
 <packages>
   <package id="ChamberLib" version="0.11" targetFramework="net40" />
   <package id="FbxSharp" version="0.6" targetFramework="net45" />
-  <package id="NUnit" version="2.6.4" targetFramework="net45" />
+  <package id="NUnit" version="3.12.0" targetFramework="net40" />
+  <package id="NUnit.ConsoleRunner" version="3.10.0" targetFramework="net40" />
 </packages>

--- a/MatrixHelper.cs
+++ b/MatrixHelper.cs
@@ -4,7 +4,7 @@ namespace ChamberLib.FbxSharp
 {
     public static class MatrixHelper
     {
-        public static ChamberLib.Matrix ToChamber(this global::FbxSharp.Matrix m)
+        public static ChamberLib.Matrix ToChamber(this global::FbxSharp.FbxMatrix m)
         {
             return
                 new Matrix(

--- a/VectorHelper.cs
+++ b/VectorHelper.cs
@@ -4,7 +4,7 @@ namespace ChamberLib.FbxSharp
 {
     public static class VectorHelper
     {
-        public static ChamberLib.Vector2 ToChamber(this global::FbxSharp.Vector2 v)
+        public static ChamberLib.Vector2 ToChamber(this global::FbxSharp.FbxVector2 v)
         {
             return
                 new Vector2(
@@ -12,7 +12,7 @@ namespace ChamberLib.FbxSharp
                     (float)v.Y);
         }
 
-        public static ChamberLib.Vector3 ToChamber(this global::FbxSharp.Vector3 v)
+        public static ChamberLib.Vector3 ToChamber(this global::FbxSharp.FbxVector3 v)
         {
             return
                 new Vector3(
@@ -21,7 +21,7 @@ namespace ChamberLib.FbxSharp
                     (float)v.Z);
         }
 
-        public static ChamberLib.Vector4 ToChamber(this global::FbxSharp.Vector4 v)
+        public static ChamberLib.Vector4 ToChamber(this global::FbxSharp.FbxVector4 v)
         {
             return
                 new Vector4(

--- a/pre-build.py
+++ b/pre-build.py
@@ -8,7 +8,7 @@ git_desc = os.popen('git describe --always --tags --abbrev=40 --long').read().rs
 print('Writing git description: {}\n'.format(git_desc))
 
 filename = "AssemblyInfo.Git.cs"
-if len(sys.argv) > 1 or sys.argv[1]:
+if len(sys.argv) > 1 and sys.argv[1]:
     filename = sys.argv[1]
 
 with open(filename, 'w') as f:


### PR DESCRIPTION
The [FbxSharp]() library had a PR to [rename a number of classes](https://github.com/izrik/FbxSharp/pull/37), to more closely match the naming of the C++ FBX SDK. This PR updates the `FbxModelImporter` class to use the new names.